### PR TITLE
General improvements for 0.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,7 +85,7 @@ task bakeAssetsList {
         listFile << paths.size() << "\n"
 
         paths.each { File file ->
-            listFile << file.getPath().replace(assetsDir.getAbsolutePath() + "/", "") << "\n"
+            listFile << file.getPath().replace(assetsDir.getAbsolutePath() + "/", "./") << "\n"
             listFile << (file.isDirectory() ? "D" : "F") << " "
             listFile << file.length() << "\n"
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:replace="android:theme">
+        tools:replace="android:theme"
+        android:requestLegacyExternalStorage="true">
 
         <activity
             android:name="com.marathon.alephone.MainActivity"
@@ -32,4 +33,7 @@
         </activity>
 
     </application>
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/app/src/main/java/com/marathon/alephone/MainActivity.java
+++ b/app/src/main/java/com/marathon/alephone/MainActivity.java
@@ -2,29 +2,81 @@ package com.marathon.alephone;
 
 import android.content.res.AssetManager;
 import android.os.Bundle;
+import android.os.Environment;
 
 import org.libsdl.app.SDLActivity;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
 
 public class MainActivity extends SDLActivity {
     private AssetManager am = null;
 
     public static native void setAssetManager(AssetManager mgr);
+    public static native void setScenarioPath(String path);
+
+    protected void updateScenarioPath()
+    {
+        File extPath = Environment.getExternalStorageDirectory();
+
+        if (!extPath.canRead())
+        {
+            return;
+        }
+
+        File scenarioSpec = new File(extPath, "AlephOneScenario.txt");
+
+        if (!scenarioSpec.canRead())
+        {
+            return;
+        }
+
+        try {
+            FileInputStream fis = new FileInputStream(scenarioSpec);
+
+            byte[] data = new byte[(int)scenarioSpec.length()];
+            fis.read(data);
+            fis.close();
+
+            String path = new String(data, "UTF-8").trim();
+
+            if (path.startsWith("#"))
+            {
+                return;
+            }
+
+            File scenarioPath = new File(path);
+
+            if (scenarioPath.canRead() && scenarioPath.isDirectory())
+            {
+                setScenarioPath(path);
+            }
+        } catch (FileNotFoundException e) {
+            return;
+        } catch (IOException e) {
+            return;
+        }
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.am = getResources().getAssets();
         setAssetManager(am);
+        updateScenarioPath();
     }
 
     @Override
     protected String[] getLibraries() {
         return new String[] {
-                "hidapi",
                 "SDL2",
                 "SDL2_image",
                 "SDL2_mixer",
-                // "SDL2_net",
+                "SDL2_net",
                 "SDL2_ttf",
                 "main"
         };


### PR DESCRIPTION
- :sparkles: Adds the ability to load scenarios by overriding the data path by writing it in a AlephOneScenario.txt file in the root of the external storage. Closes #26.
- :arrow_up: Updates AlephOne to the latest version with lots of improvements. Probably closes #24. Closes #14.
- :sparkles: Adds back button support. Closes #20.